### PR TITLE
feat: use addon mixin to abstract Provide/Inject API

### DIFF
--- a/src/addons/Mixin.js
+++ b/src/addons/Mixin.js
@@ -1,0 +1,3 @@
+export default {
+  inject: ['$hooper']
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import Hooper from './Hooper.vue';
 import Slide from './Slide.vue';
+import addonMixin from './addons/Mixin';
 import Icons from './addons/Icons';
 import Progress from './addons/Progress.vue';
 import Pagination from './addons/Pagination.vue';
 import Navigation from './addons/Navigation.vue';
 
-export { Hooper, Slide, Progress, Pagination, Navigation, Icons };
+export { Hooper, Slide, Progress, Pagination, Navigation, Icons, addonMixin };
+
 export default Hooper;


### PR DESCRIPTION
This is useful when developers who are not familiar with Provide/Inject API try to create custom addons, this can be also a useful platform for future upgrades to the addon API.

The reason behind this PR is:

> provide and inject are primarily provided for advanced plugin / component library use cases. It is NOT recommended to use them in generic application code.

So I would like to respect this intention by abstracting the behavior behind a mixin which is more future proof in-case we don't use the API for injections.

