### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ yarn add hooper
 <template>
 
 <script>
-  import { Hooper, Slide } form 'hooper';
+  import { Hooper, Slide } from 'hooper';
 
   export default {
     name: 'App',


### PR DESCRIPTION
I found a simple typo

import { Hooper, Slide } **form** 'hooper';
↓
import { Hooper, Slide } **from** 'hooper';