### PR TITLE
Typo fixes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ yarn add hooper
     </slide>
     ...
   </hooper>
-<template>
+</template>
 
 <script>
   import { Hooper, Slide } from 'hooper';
@@ -70,7 +70,7 @@ you can combine all settings in one object and pass it using `setting` prop
     ...
 
   </hooper>
-<template>
+</template>
 
 <script>
   import { Hooper, Slide } from 'hooper';
@@ -109,7 +109,7 @@ you can pass an array of breaking points to the carousel settings, to specify a 
     ...
 
   </hooper>
-<template>
+</template>
 
 <script>
   import { Hooper, Slide } from 'hooper';
@@ -214,7 +214,7 @@ Available Addons:
     <hooper-pagination slot="hooper-addons"></hooper-pagination>
     <hooper-progress slot="hooper-addons"></hooper-progress>
   </hooper>
-<template>
+</template>
 
 <script>
   import { 


### PR DESCRIPTION
Hi thanks for awesome plugin. Added missing forward slash in the template closing tag.