### PR TITLE
fix: import { Hooper, Slide } from 'hooper'; will make an error

### DIFF
--- a/src/Hooper.vue
+++ b/src/Hooper.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-import { getInRange, now, Timer, normalizeSlideIndex } from './utils';
+import { getInRange, now, Timer, normalizeSlideIndex, mergeObjects } from './utils';
 
 export default {
   name: 'Hooper',
@@ -311,7 +311,7 @@ export default {
     },
     initDefaults () {
       this.breakpoints = this.settings.breakpoints;
-      this.defaults = {...this.$props, ...this.settings};
+      this.defaults = mergeObjects({}, this.$props, this.settings);
       this.$settings = this.defaults;
     },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,3 +45,15 @@ export function normalizeSlideIndex (index, slidesCount) {
   }
   return index % slidesCount;
 }
+
+export function mergeObjects() {
+  var resObj = {};
+  for(var i=0; i < arguments.length; i += 1) {
+       var obj = arguments[i],
+           keys = Object.keys(obj);
+       for(var j=0; j < keys.length; j += 1) {
+           resObj[keys[j]] = obj[keys[j]];
+       }
+  }
+  return resObj;
+}


### PR DESCRIPTION
Hi,

I made a change to prune error dispatch of referred issue, only not using `{.., ...}` functionality.

I was use `Object.assign({}, ...)` but them not was optimized by Babel, so I have added an new util method to `mergeObjects` instead.

Fix #40 