### PR TITLE
fix: touch swipe in iOS

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -218,10 +218,10 @@ export default {
         this.initAutoPlay();
       }
       if (this.config.mouseDrag) {
-        this.$refs.track.addEventListener('mousedown', this.onDragStart);
+        this.$refs.list.addEventListener('mousedown', this.onDragStart);
       }
       if (this.config.touchDrag) {
-        this.$refs.track.addEventListener('touchstart', this.onDragStart, {
+        this.$refs.list.addEventListener('touchstart', this.onDragStart, {
           passive: true
         });
       }
@@ -588,7 +588,8 @@ function renderBody(h) {
     h(
       'div',
       {
-        class: 'hooper-list'
+        class: 'hooper-list',
+        ref: 'list'
       },
       children
     )


### PR DESCRIPTION
fixes touch event behaviour
so swiping is possible not only on the first slide

fixes touch event when infiniteScrolling is true (#108, #98)

tested:
Safari on iOS 12.3.1 (iPad 6)
Safari on iOS 1.3.3 (iPhone )
Samsung Internet on Android 6.1 (Samsung Galaxy Tab 2)
Firefox 68 on Android 6.1 (Samsung Galaxy Tab 2)
Chrome 75 on Android 7 (Huawei MediaPad M3 Lite 10)