### PR TITLE
fix: add type="button" to hooper-indicator buttons

### DIFF
--- a/src/addons/Pagination.js
+++ b/src/addons/Pagination.js
@@ -7,9 +7,11 @@ function renderFraction(h, current, totalCount) {
 
 function renderIndicator(h, index, isCurrent, onClick) {
   return h('li', [
-    h('button', { class: { 'hooper-indicator': true, 'is-active': isCurrent }, on: { click: onClick } }, [
-      h('span', { class: 'hooper-sr-only' }, `item ${index}`)
-    ])
+    h(
+      'button',
+      { class: { 'hooper-indicator': true, 'is-active': isCurrent }, on: { click: onClick }, type: 'button' },
+      [h('span', { class: 'hooper-sr-only' }, `item ${index}`)]
+    )
   ]);
 }
 

--- a/src/addons/Pagination.js
+++ b/src/addons/Pagination.js
@@ -9,7 +9,11 @@ function renderIndicator(h, index, isCurrent, onClick) {
   return h('li', [
     h(
       'button',
-      { class: { 'hooper-indicator': true, 'is-active': isCurrent }, on: { click: onClick }, type: 'button' },
+      {
+        class: { 'hooper-indicator': true, 'is-active': isCurrent },
+        on: { click: onClick },
+        attrs: { type: 'button' }
+      },
       [h('span', { class: 'hooper-sr-only' }, `item ${index}`)]
     )
   ]);


### PR DESCRIPTION
**Describe the bug**

Hooper Pagination indicator uses button elements. They are used without type attribute. So, they behave as form submit buttons.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Attributes

This behavior is problematic when Hooper is used inside a form.

**To Reproduce**

```
  <form method="get" action="">
    <hooper>
      <slide>
        slide 1
      </slide>
      <slide>
        slide 2
      </slide>
      <pagination slot="hooper-addons" />
    </hooper>
  </form>
```

Repro is also available here:
https://github.com/ryo-utsunomiya/repro-hooper-button-submit

**Expected behavior**

Pagination indicators have `type="button"` attribute so that they don't submit form.

**Screenshots**

N/A

**Desktop (please complete the following information):**
 - OS: Windows 10
 - Browser Chrome 75
 - Version 0.3.2

**Smartphone (please complete the following information):**

N/A

**Additional context**

This PR is not tested because I couldn't build Hooper on Windows. Feel free to close this PR and create new one.
