### PR TITLE
fix: detect direction and prevent scrolling from trigger slide update

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -331,10 +331,17 @@ export default {
       if (this.isSliding) {
         return;
       }
+
       this.endPosition.x = this.isTouch ? event.touches[0].clientX : event.clientX;
       this.endPosition.y = this.isTouch ? event.touches[0].clientY : event.clientY;
-      this.delta.x = this.endPosition.x - this.startPosition.x;
-      this.delta.y = this.endPosition.y - this.startPosition.y;
+      const deltaX = this.endPosition.x - this.startPosition.x;
+      const deltaY = this.endPosition.y - this.startPosition.y;
+      if (!this.config.vertical && Math.abs(deltaX) <= Math.abs(deltaY)) {
+        // Maybe scrolling.
+        return;
+      }
+      this.delta.y = deltaY;
+      this.delta.x = deltaX;
 
       if (!this.isTouch) {
         event.preventDefault();

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -310,7 +310,6 @@ export default {
         this.update();
       });
     },
-
     // events handlers
     onDragStart(event) {
       this.isTouch = event.type === 'touchstart';
@@ -327,6 +326,17 @@ export default {
       document.addEventListener(this.isTouch ? 'touchmove' : 'mousemove', this.onDrag);
       document.addEventListener(this.isTouch ? 'touchend' : 'mouseup', this.onDragEnd);
     },
+    isInvalidDirection(deltaX, deltaY) {
+      if (!this.config.vertical) {
+        return Math.abs(deltaX) <= Math.abs(deltaY);
+      }
+
+      if (this.config.vertical) {
+        return Math.abs(deltaY) <= Math.abs(deltaX);
+      }
+
+      return false;
+    },
     onDrag(event) {
       if (this.isSliding) {
         return;
@@ -336,10 +346,11 @@ export default {
       this.endPosition.y = this.isTouch ? event.touches[0].clientY : event.clientY;
       const deltaX = this.endPosition.x - this.startPosition.x;
       const deltaY = this.endPosition.y - this.startPosition.y;
-      if (!this.config.vertical && Math.abs(deltaX) <= Math.abs(deltaY)) {
-        // Maybe scrolling.
+      // Maybe scrolling.
+      if (this.isInvalidDirection(deltaX, deltaY)) {
         return;
       }
+
       this.delta.y = deltaY;
       this.delta.x = deltaX;
 


### PR DESCRIPTION
This PR ensures hooper is aware of the direction of the drag, if the user drags vertically and the slider is configured to be horizontal (default) it should ignore the action.

This is done by comparing if deltaY is larger than deltaX, which will always be the case if they are indeed scrolling.

Requires more testing as this could introduce false positives.

closes #84