### PR TITLE
feat: add the ability to override the playSpeed on a per slide basis

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,7 @@
 # API
 
 ## Props
+### hooper component props 
 
 |Prop             |Default |Description|
 |-----------------|-----|-----------|
@@ -23,6 +24,12 @@
 |`hoverPause`     |true |pause autoPlay if the mouse enters the slide.|
 |`trimWhiteSpace` |false|limit carousel to slide only when there will be no completely empty slide-space.|
 |`settings`       |{ }  |an object to pass all settings.|
+
+### slider component props
+
+|Prop              |Default| Description|
+|------------------|-------|------------|
+|`duration`        |null   | This optionally overrides the slide visibility time (in millis) from the default set by the playSpeed prop on the main component.|
 
 ## Slots
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -519,30 +519,6 @@ export default {
 
 ## Auto Playing
 
-<hooper :progress="true" :autoPlay="true" :playSpeed="2000">
-  <slide>
-    slide 1
-  </slide>
-  <slide>
-    slide 2
-  </slide>
-  <slide>
-    slide 3
-  </slide>
-  <slide>
-    slide 4
-  </slide>
-  <slide>
-    slide 5
-  </slide>
-  <slide>
-    slide 6
-  </slide>
-
-  <hooper-navigation slot="hooper-addons"></hooper-navigation>
-  <hooper-progress slot="hooper-addons"></hooper-progress>
-</hooper>
-
 ```vue
 <hooper :progress="true" :autoPlay="true" :playSpeed="2000">
   <slide>
@@ -563,6 +539,17 @@ export default {
   <slide>
     slide 6
   </slide>
+</hooper>
+```
+## Auto Playing with per slide duration for a fullscreen display
+```vue
+<hooper :autoPlay="true" :playSpeed="2000" :hoverPause="false">
+ <slide :duration="1000">
+  slide 1 - custom duration of 1000ms 
+ </slide>
+ <slide>
+  slide 2 - default duration of 2000ms
+</slide>
 </hooper>
 ```
 

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -258,6 +258,11 @@ export default {
       }
       window.addEventListener('resize', this.update);
     },
+    getCurrentSlideTimeout() {
+      const curIdx = normalizeSlideIndex(this.currentSlide, this.slidesCount);
+      const children = normalizeChildren(this);
+      return children[curIdx].componentOptions.propsData.duration;
+    }, // switched to using a timeout which defaults to the prop set on this component, but can be overridden on a per slide basis.
     initAutoPlay() {
       this.timer = new Timer(() => {
         if (
@@ -267,14 +272,17 @@ export default {
           this.isFocus ||
           !this.$props.autoPlay
         ) {
+          this.timer.set(this.getCurrentSlideTimeout());
           return;
         }
         if (this.currentSlide === this.slidesCount - 1 && !this.config.infiniteScroll) {
           this.slideTo(0);
+          this.timer.set(this.getCurrentSlideTimeout());
           return;
         }
         this.slideNext();
-      }, this.config.playSpeed);
+        this.timer.set(this.getCurrentSlideTimeout());
+      }, this.getCurrentSlideTimeout());
     },
     initDefaults() {
       this.breakpoints = this.settings.breakpoints;
@@ -340,6 +348,7 @@ export default {
         if (this.timer) {
           this.timer.stop();
           if (this.$props.autoPlay) {
+            this.timer.set(this.getCurrentSlideTimeout());
             this.timer.start();
           }
         }

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -12,6 +12,10 @@ export default {
     index: {
       type: Number,
       required: true
+    },
+    duration: {
+      type: Number,
+      default: null
     }
   },
   computed: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,14 +6,14 @@ export function now() {
   return Date.now();
 }
 
-export function Timer(callback, time) {
+export function Timer(callback, defaultTime) {
   this.create = function() {
-    return window.setInterval(callback, time);
+    return window.setTimeout(callback, defaultTime);
   };
 
   this.stop = function() {
     if (this.timer) {
-      window.clearInterval(this.timer);
+      window.clearTimeout(this.timer);
       this.timer = null;
     }
   };
@@ -24,9 +24,9 @@ export function Timer(callback, time) {
     }
   };
 
-  this.restart = function() {
-    this.stop();
-    this.start();
+  this.set = function(newTime) {
+    const timeout = newTime || defaultTime;
+    this.timer = window.setTimeout(callback, timeout);
   };
   this.timer = this.create();
 }


### PR DESCRIPTION
This PR supersedes https://github.com/baianat/hooper/pull/89 with updates from master.
Please double check that the logic in `getCurrentSlideTimeout()` is not going to be too slow/excessively memory consuming. Unfortunately I've got not enough expertise in terms of how Vue rendering engine  works to tie the way that logic in the previous PR worked with the latest changes made to rendering.
I'm happy to address any comments though and improve things if you point me in the direction of some useful resources.