### PR TITLE
Renames carouselData property to myCarouselData

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -756,12 +756,12 @@ export default {
 export default {
   data () {
     return {
-      carouselData: 0
+      myCarouselData: 0
     }
   },
   watch: {
     carouselData () {
-      this.$refs.carousel.slideTo(this.carouselData);
+      this.$refs.carousel.slideTo(this.myCarouselData);
     }
   },
   methods: {


### PR DESCRIPTION
Method updateCarousel() makes reference to data property this.myCarouselData which does not exist. Judging from previous examples and from the method updateCarousel(payload) (already referencing this.myCarouselData), the data property should be called myCarouselData and not carouselData.