### PR TITLE
fix(pagination): indication count when itemstoshow is not 1

### DIFF
--- a/src/addons/Pagination.js
+++ b/src/addons/Pagination.js
@@ -55,7 +55,7 @@ export default {
     }
   },
   render(h) {
-    const totalCount = this.$hooper.slidesCount;
+    const totalCount = this.$hooper.slidesCount - this.$hooper.trimStart - this.$hooper.trimEnd + 1;
     const children =
       this.mode === 'indicator'
         ? renderDefault(h, this.currentSlide, totalCount, index => this.$hooper.slideTo(index))


### PR DESCRIPTION
when itemsToShow is set to 2, there is one indication point more than there should be.
for itemsToShow = 3, 2 indication points and so on.

This PR fixes this pagination behaviour.