### PR TITLE
fix: Prevent listening child transitions to honor the given transition time

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -426,8 +426,8 @@ export default {
       document.removeEventListener(this.isTouch ? 'touchend' : 'mouseup', this.onDragEnd);
       this.restartTimer();
     },
-    onTransitionend() {
-      if (!e.target.classList.contains('hooper-track')) {
+    onTransitionend(event) {
+      if (!event.target.classList.contains('hooper-track')) {
         return;
       }
       this.isSliding = false;

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -427,6 +427,9 @@ export default {
       this.restartTimer();
     },
     onTransitionend() {
+      if (!e.target.classList.contains('hooper-track')) {
+        return;
+      }
       this.isSliding = false;
       this.$emit('afterSlide', {
         currentSlide: this.currentSlide


### PR DESCRIPTION
It fix issues where transition isn't respected when shorter transition timing than the hooper one exist in the child components. This caused a jump during the animation because the `.hooper-track` was instantly moving to its final position (without honoring its defined animation timing.)