### PR TITLE
Update api.md with @loaded event description.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -120,6 +120,10 @@ Restart auto-play timer.
 
 ## Events
 
+### @loaded
+
+Emits after slider has been initialized. 
+
 ### @beforeSlide
 
 Emits before sliding start occurring.


### PR DESCRIPTION
I had to look up this event in the source code to figure out when the slider is fully initialized and is available in $refs. Thought that others might find it useful as well.