### PR TITLE
fix: misstatement in examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -772,7 +772,7 @@ export default {
       this.$refs.carousel.slideNext();
     },
     updateCarousel(payload) {
-      this.myCarouselData = payload.currentSlide;
+      this.carouselData = payload.currentSlide;
     }
   }
 }


### PR DESCRIPTION
Fixed misstatement in example code of  "Custom Controllers".
In `updateCarousel()` method, `this.myCarouselData` must be `this.carouselData` as it defined in data section.